### PR TITLE
Fix issues related to an rlang problem with NULL

### DIFF
--- a/R/.Rhistory
+++ b/R/.Rhistory
@@ -1,5 +1,0 @@
-install()
-document()
-install()
-install()
-install()

--- a/R/dataplot.R
+++ b/R/dataplot.R
@@ -16,8 +16,8 @@ dataplot <-
            y_facet = FALSE,
            label_vars = FALSE,
            percentage = FALSE,
-           colour_vars = NULL,
-           fill_vars = NULL,
+           colour_vars = FALSE,
+           fill_vars = FALSE,
            colour_palette = NULL,
            fill_palette = NULL,
            pos = "dodge",
@@ -27,6 +27,12 @@ dataplot <-
            legend_labels = ggplot2::waiver(),
            legend_rev = FALSE,
            flip = FALSE){
+
+    ## comment 30/4/18 AK
+    ## quo_name(quo(NULL)) currently fails, see https://github.com/r-lib/rlang/issues/430
+    ## all variables above that have a default of NULL could cause the following error:
+    ## #> Error: `expr` must quote a symbol, scalar, or call
+    ## set to FALSE instead
 
     p <- ggplot2::ggplot(data = data_frame)
 

--- a/R/elements.R
+++ b/R/elements.R
@@ -1,5 +1,5 @@
 #' Add a bar element
-bar <- function(p, bar_width = NULL, pos = "dodge", barplot_alpha = 1){
+bar <- function(p){
   p <- p + ggplot2::geom_bar(
                       position = pos,
                       alpha = barplot_alpha,

--- a/R/plot_barplot.R
+++ b/R/plot_barplot.R
@@ -99,13 +99,24 @@
 plot_barplot <- function(...) {
   set_bar_theme()
   elements <- list(bar,
+                   bar_labels,
                    scales,
                    colour,
                    legend,
+                   facet,
                    flip_axes,
-                   bar_labels,
                    x_ticks,
-                   title)
+                   title
+                   )
+  ## 30/4/18 AK
+  ## facet interacts with title
+  ## If you run into the following error (after checking the data) it may be a problem
+  ## with the relative placements of facet and title and possbily flip_axes. Reproduce
+  ## error as follows: move facet after title and try to create a plot with a facet and
+  ## a title. It will fail with the following error:
+  ##
+  ## Error in combine_vars(data, params$plot_env, cols, drop = params$drop)
+  ## At least one layer must contain all variables used for facetting
   d <- dataplot(..., element_function=elements)
   return(d)
 }


### PR DESCRIPTION
Fixes an issue related to an rlang issue with NULL default values to
variables. According to https://github.com/r-lib/rlang/issues/430
quo_name(quo(NULL)) fails. NULL defaults were replaced with FALSE.

Added a facet to barplot, which was previously missing.